### PR TITLE
Add support for Rainmeter WebNowPlaying plugin

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -6,7 +6,7 @@
         "message": "Unsupported OS"
     },
     "unsupported_os_message": {
-        "message": "Sorry, but your OS is not supported. Currently we support only GNU/Linux and *BSD. Windows and maybe macOS support is planned"
+        "message": "Sorry, but your OS is not supported. Currently we support only GNU/Linux and *BSD and Windows. MacOS support is planned"
     },
     "click_uninstall": {
         "message": "Click to uninstall"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -6,7 +6,7 @@
         "message": "ОС не поддерживается"
     },
     "unsupported_os_message": {
-        "message": "Увы, ваша ОС не поддерживается. Пока поддерживается только GNU/Linux и *BSD. Планируется поддержка Windows и, возможно, macOS"
+        "message": "Увы, ваша ОС не поддерживается. Пока поддерживается только GNU/Linux и *BSD и Windows. Планируется поддержка macOS"
     },
     "click_uninstall": {
         "message": "Кликните, чтобы удалить"

--- a/background/adapters/mpris2.js
+++ b/background/adapters/mpris2.js
@@ -1,0 +1,38 @@
+'use strict';
+
+define([
+    'background/listener-manager',
+], (ListenerManager) => {
+    return class {
+        /**
+         * @constructor
+         */
+        constructor() {
+            /**
+             * Called when a message from an external application is received.
+             * @param {object} message WebMediaController message
+             */
+            this.onMessage = new ListenerManager();
+        }
+
+        /**
+         * Connect to application.
+         * @returns {Promise} Promise resolved with adapter instance
+         * @throws Error if adapter is not initialized
+         */
+        connect() {
+            return new Promise(resolve => {
+                this.port = chrome.runtime.connectNative('me.f1u77y.web_media_controller');
+                this.port.onMessage.addListener((message) => {
+                    this.onMessage.call(message);
+                });
+
+                resolve(this);
+            });
+        }
+
+        sendMessage(message) {
+            this.port.postMessage(message);
+        }
+    };
+});

--- a/background/adapters/rainmeter.js
+++ b/background/adapters/rainmeter.js
@@ -1,0 +1,149 @@
+'use strict';
+
+/**
+ * Application adapter for Rainmeter WebNowPlaying plugin.
+ */
+
+define([
+    'background/utils',
+    'background/listener-manager',
+], (Utils, ListenerManager) => {
+    const WEBSOCKET_ADDRESS = 'ws://127.0.0.1:8974/';
+    const RECONNECT_INTERVAL = 5000;
+
+    /**
+     * WebMediaController => Rainmeter
+     * @type {object}
+     */
+    const messageMap = {
+        name: 'PLAYER',
+        artist: 'ARTIST',
+        title: 'TITLE',
+        album: 'ALBUM',
+        artUrl: 'COVER',
+        playbackStatus: 'STATE',
+        currentTime: 'POSITION',
+        length: 'DURATION',
+    };
+
+    /**
+     * Rainmeter => WebMediaController
+     * @type {object}
+     */
+    const commandsMap = {
+        playpause: 'playPause',
+        play: 'play',
+        pause: 'pause',
+        previous: 'previous',
+        next: 'next',
+    };
+
+    const playingStateMap = {
+        'stopped': 0,
+        'playing': 1,
+        'paused': 2,
+    };
+
+    return class {
+        /**
+         * @constructor
+         */
+        constructor() {
+            /**
+             * Called when a message from an external application is received.
+             * @param {object} message WebMediaController message
+             */
+            this.onMessage = new ListenerManager();
+        }
+
+        /**
+         * Connect to application.
+         * @returns {Promise} Promise resolved with adapter instance
+         * @throws Error if adapter is not initialized
+         */
+        connect() {
+            return new Promise((resolve, reject) => {
+                this.webSocket = new WebSocket(WEBSOCKET_ADDRESS);
+                this.webSocket.onmessage = (message) => {
+                    this.onWebSocketMessage(message);
+                };
+
+                this.webSocket.onopen = () => {
+                    this.webSocket.onopen = null;
+                    this.webSocket.onclose = () => {
+                        setTimeout(() => {
+                            this.connect();
+                        }, RECONNECT_INTERVAL);
+                    };
+
+                    resolve(this);
+                }
+                this.webSocket.onerror = () => {
+                    this.webSocket.onerror = null;
+                    reject(new Error('Connection is not established'));
+                }
+            });
+        }
+
+        /**
+         * Send message to an external application.
+         * @param {object} message WebMediaController message
+         */
+        sendMessage(message) {
+            let { name, value } = message;
+
+            if (name === 'trackInfo') {
+                let trackInfo = value;
+                for (let prop in trackInfo) {
+                    let rainmeterMsg = messageMap[prop];
+                    if (!rainmeterMsg) {
+                        continue;
+                    }
+
+                    this.sendMessageViaWebSocket(prop, trackInfo[prop]);
+                }
+                return;
+            }
+
+            this.sendMessageViaWebSocket(name, value);
+        }
+
+        /**
+         * Internal functions.
+         */
+
+        /**
+         * Сalled when a message from WebSocket is received.
+         * @param {object} message WebSocket message
+         */
+        onWebSocketMessage(message) {
+            let rainmeterCommand = message.data.toLowerCase();
+            let command = commandsMap[rainmeterCommand];
+
+            this.onMessage.call({ command });
+        }
+
+        /**
+         * Send message using WebSocket.
+         * @param  {string} name Message name
+         * @param  {string} value Message value
+         */
+        sendMessageViaWebSocket(name, value) {
+            // Convert value
+            switch (name) {
+                case 'playbackStatus': {
+                    value = playingStateMap[value];
+                    break;
+                }
+                case 'length':
+                case 'currentTime': {
+                    value = Utils.secondsToMMSS(value / 1000);
+                    break;
+                }
+            }
+
+            let rMessage = messageMap[name];
+            this.webSocket.send(`${rMessage}:${value}`);
+        }
+    }
+});

--- a/background/listener-manager.js
+++ b/background/listener-manager.js
@@ -1,0 +1,25 @@
+'use strict';
+
+define(() => {
+    class ListenerManager {
+        constructor() {
+            this.listeners = new Set();
+        }
+
+        addListener(listener) {
+            this.listeners.add(listener);
+        }
+
+        removeListener(listener) {
+            this.listeners.remove(listener);
+        }
+
+        call(...args) {
+            for (let listener of this.listeners) {
+                listener(...args);
+            }
+        }
+    }
+
+    return ListenerManager;
+});

--- a/background/main.js
+++ b/background/main.js
@@ -2,54 +2,106 @@
 
 define([
     'background/tab-chooser',
-], (chooser) => {
-    const port = chrome.runtime.connectNative('me.f1u77y.web_media_controller');
-    port.onDisconnect.addListener(() => {
-        chrome.runtime.getPlatformInfo((info) => {
-            if (['linux', 'openbsd'].includes(info.os)) {
-                chrome.notifications.create({
-                    type: 'basic',
-                    iconUrl: chrome.runtime.getURL('icons/disconnect-16.svg'),
-                    title: chrome.i18n.getMessage('native_not_installed_title'),
-                    message: chrome.i18n.getMessage('native_not_installed_message'),
-                    contextMessage: chrome.i18n.getMessage('click_instructions'),
-                    isClickable: true,
-                }, (currentId) => {
-                    chrome.notifications.onClicked.addListener(function instruct(id) {
-                        if (id !== currentId) return;
-                        chrome.notifications.onClicked.removeListener(instruct);
-                        chrome.tabs.create({
-                            url: chrome.i18n.getMessage('native_instructions_url'),
-                        });
-                    });
-                });
-            } else {
-                chrome.notifications.create({
-                    type: 'basic',
-                    iconUrl: chrome.runtime.getURL('icons/error-22.svg'),
-                    title: chrome.i18n.getMessage('unsupported_os_title'),
-                    message: chrome.i18n.getMessage('unsupported_os_message'),
-                    contextMessage: chrome.i18n.getMessage('click_uninstall'),
-                    isClickable: true,
-                }, (currentId) => {
-                    chrome.notifications.onClicked.addListener(function uninstall(id) {
-                        if (id !== currentId) return;
-                        chrome.notifications.onClicked.removeListener(uninstall);
-                        chrome.management.uninstallSelf();
-                    });
-                });
+    'background/adapters/mpris2',
+    'background/adapters/rainmeter',
+    'background/utils',
+], (chooser, Mpris2Adapter, RainmeterAdapter, Utils) => {
+    const SUPPORTED_OSES = ['linux', 'openbsd', 'win'];
+
+    setupAppAdapter();
+
+    /**
+     * Entry point.
+     */
+    function setupAppAdapter() {
+        isOsSupported().then(isSupported => {
+            if (!isSupported) {
+                notifyOsIsNotSupported();
+                return;
             }
+
+            getAppAdapter().then(appAdapter => {
+                return appAdapter.connect();
+            }).then(appAdapter => {
+                appAdapter.onMessage.addListener((message) => {
+                    chooser.sendMessage(_.defaults(message, { argument: null }));
+                });
+                chooser.onMessage.addListener((message) => {
+                    appAdapter.sendMessage(message);
+                });
+            }).catch(showInstructions);
         });
-    });
+    }
 
-    port.onMessage.addListener((message) => {
-        chooser.sendMessage(_.defaults(message, { argument: null }));
-    });
-    chooser.onMessage.addListener((message) => {
-        port.postMessage(_.defaults(message, { value: null }));
-    });
+    /**
+     * Return application adapter depends on running OS.
+     * @returns {object} Application adapter
+     */
+    function getAppAdapter() {
+        return Utils.getOsName().then(name => {
+            if (['linux', 'openbsd'].includes(name)) {
+                return new Mpris2Adapter();
+            } else if (name === 'win') {
+                return new RainmeterAdapter();
+            }
 
-    chrome.pageAction.onClicked.addListener((tab) => {
-        chooser.changeTab(tab.id);
-    });
+            throw new Error('Unable to get application adapter');
+        });
+    }
+
+    /**
+     * Check if currently running OS is supported.
+     * @return {boolean} Check result
+     */
+    function isOsSupported() {
+        return Utils.getOsName().then(name => {
+            return SUPPORTED_OSES.includes(name);
+        });
+    }
+
+    /**
+     * Show notification if currently running OS is not supported.
+     */
+    function notifyOsIsNotSupported() {
+        chrome.notifications.create({
+            type: 'basic',
+            iconUrl: chrome.runtime.getURL('icons/error-22.svg'),
+            title: chrome.i18n.getMessage('unsupported_os_title'),
+            message: chrome.i18n.getMessage('unsupported_os_message'),
+            contextMessage: chrome.i18n.getMessage('click_uninstall'),
+            isClickable: true,
+        }, (currentId) => {
+            chrome.notifications.onClicked.addListener(function uninstall(id) {
+                if (id !== currentId) {
+                    return;
+                }
+                chrome.notifications.onClicked.removeListener(uninstall);
+                chrome.management.uninstallSelf();
+            });
+        });
+    }
+
+    /**
+     * Show notification with instructions.
+     */
+    function showInstructions() {
+        chrome.notifications.create({
+            type: 'basic',
+            iconUrl: chrome.runtime.getURL('icons/disconnect-16.svg'),
+            title: chrome.i18n.getMessage('native_not_installed_title'),
+            message: chrome.i18n.getMessage('native_not_installed_message'),
+            contextMessage: chrome.i18n.getMessage('click_instructions'),
+            isClickable: true,
+        }, (currentId) => {
+            chrome.notifications.onClicked.addListener(function instruct(id) {
+                if (id !== currentId) {
+                    return;
+                }
+                chrome.notifications.onClicked.removeListener(instruct);
+                chrome.tabs.create({
+                    url: chrome.i18n.getMessage('native_instructions_url'),
+                });
+            });
+        });
+    }
 });

--- a/background/tab-chooser.js
+++ b/background/tab-chooser.js
@@ -2,28 +2,9 @@
 
 define([
     'background/utils',
+    'background/listener-manager',
     'common/prefs',
-], (Utils, prefs) => {
-    class ListenerManager {
-        constructor() {
-            this.listeners = new Set();
-        }
-
-        addListener(listener) {
-            this.listeners.add(listener);
-        }
-
-        removeListener(listener) {
-            this.listeners.remove(listener);
-        }
-
-        call(...args) {
-            for (let listener of this.listeners) {
-                listener(...args);
-            }
-        }
-    }
-
+], (Utils, ListenerManager, prefs) => {
     class TabChooser {
         constructor() {
             this.ports = new Map();

--- a/background/utils.js
+++ b/background/utils.js
@@ -20,5 +20,36 @@ define(() => {
         return { name, value };
     }
 
-    return { makeIconPath, capitalizeValue };
+    /**
+     * Convert time in seconds to string in MM:SS format.
+     * @param  {number} seconds Seconds
+     * @returns {string} String in MM:SS format
+     */
+    function secondsToMMSS(num) {
+        let seconds = Math.floor(num);
+        let minutes = Math.floor(seconds / 60);
+        seconds -= minutes * 60;
+
+        if (minutes < 10) {
+            minutes = `0${minutes}`;
+        }
+        if (seconds < 10) {
+            seconds = `0${seconds}`;
+        }
+        return `${minutes}:${seconds}`;
+    }
+
+    /**
+     * Get currently running OS via Chrome API.
+     * @returns {string} OS short name
+     */
+    function getOsName() {
+        return new Promise((resolve) => {
+            chrome.runtime.getPlatformInfo((info) => {
+                resolve(info.os);
+            });
+        });
+    }
+
+    return { makeIconPath, capitalizeValue, secondsToMMSS, getOsName };
 });


### PR DESCRIPTION
This PR adds support for Rainmeter plugin called WebNowPlaying.

### Core changes
Add new object called 'adapter', which gets messages from content scipts, transforms them (if required) and sends these messages to remote applications.

### Additional changes
ListenerManager is extracted into separated file.