### PR TITLE
Reset playback status and current time on tab close

### DIFF
--- a/background/tab-chooser.js
+++ b/background/tab-chooser.js
@@ -112,6 +112,8 @@ define([
                         trackId: '',
                     },
                 });
+                this.onMessage.call({ name: 'playbackStatus', value: 'stopped' });
+                this.onMessage.call({ name: 'currentTime', value: 0 });
                 return;
             }
             this.sendMessage('reload');


### PR DESCRIPTION
This resolves the issue when a single tab with music is closed, but a widget is displaying playing state.

The only thing I don't like the `TabChooser` knows too much about the data it sends to adapters.