### PR TITLE
Use webext_builder grunt plugin for distributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ installed and available in your `$PATH` for building.
     $ npm install
     $ npx grunt build:$browser # $browser could be 'firefox' or 'chrome'
 
-Built extension is now in `build/$browser` directory. You could load it as temporary extension
+The extension is now built in `build/$browser/`. You could load it as temporary extension
 or pack it.
 
-If you're developer, and you want `build/$browser` directory to correspond the current state of
+If you're developer, and you want `build/$browser/` to correspond the current state of
 development, you should run `npx grunt watch:$browser`.
 
 Note that every time you'll restart your browser, it won't load your version of the extension in
-`build/$browser`.
+`build/$browser/`.
 
 ### Packing
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ corresponding file and install the extension from file.
 
 ## Building
 
-You should have Node.js and npm installed and available in your `$PATH` for building.
+### Development
+
+For hacking the extension, you'll need [Node.js](https://nodejs.org/) and [npm](http://npmjs.com/)
+installed and available in your `$PATH` for building.
 
     $ npm install
     $ npx grunt build:$browser # $browser could be 'firefox' or 'chrome'
@@ -56,6 +59,8 @@ or pack it.
 
 If you're developer, and you want `build/$browser` directory to correspond the current state of
 development, you should run `npx grunt watch:$browser`.
+
+### Packing
 
 You could also pack an extension in the browser-specific format. For Firefox you need `amo.json`
 file with your credentials (`{"apiKey": "...", "apiSecret": "..."}`). You can get them via

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ corresponding file and install the extension from file.
 
 ## Building
 
-You should have node.js installed and availible in your `$PATH` for building.
+You should have Node.js and npm installed and available in your `$PATH` for building.
 
     $ npm install
     $ npx grunt build:$browser # $browser could be 'firefox' or 'chrome'
@@ -58,7 +58,7 @@ If you're developer, and you want `build/$browser` directory to correspond the c
 development, you should run `npx grunt watch:$browser`.
 
 You could also pack an extension in the browser-specific format. For Firefox you need `amo.json`
-file with your crenetials (`{"apiKey": "...", "apiSecret": "..."}`). You can get them via
+file with your credentials (`{"apiKey": "...", "apiSecret": "..."}`). You can get them via
 [this interface](https://addons.mozilla.org/en-US/developers/addon/api/key/). For Chrome you need
 `cws.json` file of form `{"privateKeyPath": "..."}`. Private key is stored locally and could be
 generated in two ways: (a) pack extension via Chrome GUI with private key field empty; (b)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,5 @@
     },
     "license": "MIT",
     "optionalDependencies": {
-        "web-ext": "^2.6.0"
     }
 }


### PR DESCRIPTION
Should fix the issue I mentioned in my last comment at #14. I couldn't test this successfully because I get the error saying the addon already exists (coudn't figure out how come this error came because you wrote you didn't publish it):
```
Running "webext_builder:firefox" (webext_builder) task
Build Firefox Signed XPI
Found manifest for extension 'Web Media Controller' version '0.8.4'
Load extension sources from 'build/firefox'
Write output zip '/var/code/doron/web-media-controller/dist/web_media_controller-0.8.4-raw.xpi'
ZIP archive generated '/var/code/doron/web-media-controller/dist/web_media_controller-0.8.4-raw.xpi'
Try to sign extension '/var/code/doron/web-media-controller/dist/web_media_controller-0.8.4-raw.xpi' with AMO
Server response: Duplicate add-on ID found. (status: 400)
Signed { success: false }
```
It seems to be working though but as if only you are allowed to sign it. Perhaps this should add an incentive to `npx grunt bump`?