### PR TITLE
Fix stylistic issues in options page

### DIFF
--- a/src/options/css/options.css
+++ b/src/options/css/options.css
@@ -14,3 +14,7 @@ body {
     margin-left: 15px;
     margin-bottom: 5px;
 }
+
+.edit-icon:hover {
+    text-decoration: none !important;
+}

--- a/src/options/options.mustache
+++ b/src/options/options.mustache
@@ -21,10 +21,10 @@
 
     <h3 i18n-text="connector_options"></h3>
 
-    <div>
+    <div class="mb-3">
         {{#connectors}}
             <div>
-                <a id="btn-edit-connector-{{id}}" href="#modal-connector" data-toggle="modal">
+                <a class="edit-icon" id="btn-edit-connector-{{id}}" href="#modal-connector" data-toggle="modal">
                     <i class="fa fa-cog fa-fw input-pattern-close-btn"></i>
                 </a>
                 <span>{{label}}</span>


### PR DESCRIPTION
Remove underline of cog icon:
![1](https://user-images.githubusercontent.com/1119267/63646637-8a046180-c71e-11e9-99f4-e2264fa1c1d9.png)

Add bottom margin:
![2](https://user-images.githubusercontent.com/1119267/63646638-8a046180-c71e-11e9-8bd1-42b8d72cec2e.png)
