### PR TITLE
Named capture groups not yet supported in Firefox

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,5 +1,5 @@
 parserOptions:
-  ecmaVersion: 2018
+  ecmaVersion: 8
   sourceType: module
 
 env:
@@ -41,7 +41,7 @@ rules:
   no-useless-call: error
   no-useless-concat: error
   no-useless-return: error
-  prefer-named-capture-group: warn
+  # prefer-named-capture-group: warn
   prefer-promise-reject-errors: error
 
   strict: [ error, global ]

--- a/src/background/url-match.js
+++ b/src/background/url-match.js
@@ -21,11 +21,13 @@ function matchPatternToRegExp(pattern) {
         return /^.*$/;
     }
 
-    const urlPartsMatch = /^(?<scheme>\*|https?|file|ftp|chrome-extension):\/\/(?<host>[^/]*)(?<file>\/.*)/.exec(pattern);
+    const urlPartsMatch = /^(\*|https?|file|ftp|chrome-extension):\/\/([^/]*)(\/.*)/.exec(pattern);
     if (!urlPartsMatch) {
         return null;
     }
-    const { scheme, host, file } = urlPartsMatch.groups;
+    const scheme = urlPartsMatch[1];
+    const host = urlPartsMatch[2];
+    const file = urlPartsMatch[3];
 
     let result = '';
 

--- a/src/connectors/soundcloud.js
+++ b/src/connectors/soundcloud.js
@@ -29,10 +29,10 @@ new class extends BaseConnector {
             artist: document.querySelector(this.artistSelector).textContent.trim(),
             track: document.querySelector(this.titleSelector).textContent.trim(),
         };
-        const match = /(?<artist>.+)\s[-–—:]\s(?<track>.+)/.exec(artistTrack.track);
+        const match = /(.+)\s[-–—:]\s(.+)/.exec(artistTrack.track);
 
-        if (match && ! /.*#\d+.*/.test(match.groups.artist)) {
-            return { artist: match.groups.artist, track: match.groups.track };
+        if (match && ! /.*#\d+.*/.test(match[1])) {
+            return { artist: match[1], track: match[2] };
         }
 
         return artistTrack;

--- a/src/content/utils.js
+++ b/src/content/utils.js
@@ -21,9 +21,9 @@ function parseLength(text, { useFirstValue = false } = {}) {
     * @return {string} Extracted URL
     */
 function extractUrlFromCssProperty(cssProperty) {
-    const match = /url\((?<quote>['"]?)(?<url>.*)\k<quote>\)/.exec(cssProperty);
+    const match = /url\((['"]?)(.*)\1\)/.exec(cssProperty);
     if (match) {
-        return match.groups.url.trim();
+        return match[2].trim();
     }
     return null;
 }


### PR DESCRIPTION
I ran into trouble updating my build of this extension. It looks like Firefox doesn't support named capture groups and so throws a syntax error for an invalid regexp group. The tracking bugzilla is here: https://bugzilla.mozilla.org/show_bug.cgi?id=1362154
From the blocking issue, it looks like this won't land until after Firefox 70.

For now, this reverts commit 2f353807fa424903407242009ae28570f02db92b and it builds, (lints,) and runs fine in Firefox 68.0.2.

If this is ok, I'll rebase #26 with the style changes on top.