### PR TITLE
Fix SoundCloud connector

### DIFF
--- a/src/connectors/soundcloud.js
+++ b/src/connectors/soundcloud.js
@@ -47,6 +47,12 @@ new class extends BaseConnector {
     }
 
     get artUrl() {
-        return super.artUrl.then((url) => url.replace('-t50x50.', '-t200x200.'));
+        return super.artUrl.then((url) => {
+            if (url) {
+                return url.replace('-t50x50.', '-t200x200.');
+            }
+
+            return '';
+        });
     }
 }();


### PR DESCRIPTION
Don't replace size parameter if cover is empty.

Example of track with no cover art: https://soundcloud.com/user-812554612/10-beartooth-infection/s-GXQi4.