### PR TITLE
Fix SoundCloud connector

### DIFF
--- a/src/connectors/soundcloud.js
+++ b/src/connectors/soundcloud.js
@@ -2,6 +2,14 @@ import BaseConnector from 'content/base-connector';
 import Utils from 'content/utils';
 import _ from 'underscore';
 
+/**
+ * Regular expression used to split artist and track.
+ * U+2013 En Dash
+ * U+2014 Em Dash
+ * U+2015 Horizontal bar
+ */
+const artistTrackRe = /(.+)\s[-:\u2013\u2014\u2015]\s(.+)/;
+
 const connector = new class extends BaseConnector {
     constructor() {
         super();
@@ -30,7 +38,7 @@ const connector = new class extends BaseConnector {
             artist: document.querySelector(this.artistSelector).textContent.trim(),
             track: document.querySelector(this.titleSelector).textContent.trim(),
         };
-        const match = /(.+)\s[-–—:]\s(.+)/.exec(artistTrack.track);
+        const match = artistTrackRe.exec(artistTrack.track);
 
         if (match && ! /.*#\d+.*/.test(match[1])) {
             return { artist: match[1], track: match[2] };


### PR DESCRIPTION
This PR fixes recognition of tracks contains a horizontal bar (U+2015) character to join artist and title.

Example of a track: https://soundcloud.com/profildeface/bleu-toucan-hanoi-cafe.

Also I used Unicode escape sequences, because it's quite hard to understand what characters are used in the regular expression:
![image](https://user-images.githubusercontent.com/1119267/67157695-49991c80-f338-11e9-948f-d4dc77215f52.png)
![image](https://user-images.githubusercontent.com/1119267/67157678-03dc5400-f338-11e9-80d5-072225e78d9e.png)

